### PR TITLE
PINARA-383

### DIFF
--- a/Myra-0.0.1/src/com/likya/myra/jef/core/Commandability.java
+++ b/Myra-0.0.1/src/com/likya/myra/jef/core/Commandability.java
@@ -106,7 +106,9 @@ public class Commandability {
 	 * @return isDisablable
 	 */
 	public static boolean isDisablableForGroup(AbstractJobType abstractJobType) {
-		return LiveStateInfoUtils.equalStates(LiveStateInfoUtils.getLastStateInfo(abstractJobType), StateName.PENDING) || LiveStateInfoUtils.equalStates(LiveStateInfoUtils.getLastStateInfo(abstractJobType), StateName.FINISHED, SubstateName.COMPLETED, StatusName.FAILED);
+		return LiveStateInfoUtils.equalStates(LiveStateInfoUtils.getLastStateInfo(abstractJobType), StateName.PENDING) 
+				|| LiveStateInfoUtils.equalStates(LiveStateInfoUtils.getLastStateInfo(abstractJobType), StateName.FINISHED, SubstateName.COMPLETED, StatusName.FAILED)
+				|| LiveStateInfoUtils.equalStates(LiveStateInfoUtils.getLastStateInfo(abstractJobType), StateName.CANCELLED, SubstateName.STOPPED, StatusName.BYEVENT);
 	}
 	
 	/**


### PR DESCRIPTION
DepExpression job update'lerde düzgün oluşmuyor.
Ekranda ilgili grupta joblar üzerinde hiçbir işlem yapılamaz hale geliyordu, bu tıkanıklık giderildi.
DepExp'nin düzenlenmesi farkılı issue ile bir sonraki release bırakıldı.